### PR TITLE
Make linkify skip trailing punctuation

### DIFF
--- a/www/index.cgi
+++ b/www/index.cgi
@@ -683,7 +683,7 @@ sub linkify {
     $value =~ s#([a-zA-Z0-9\.-]+)\@(([a-zA-Z0-9\.-]+\.)+[a-zA-Z0-9\.-]+)#$1\%$2#g;
 
     unless ($value =~ s#&lt;(https?://.+?)&gt;#'&lt;<a href="' . $rs_href->($1) . '" target="_blank">' . shorten_url($1) . '</a>&gt;'#ge) {
-        $value =~ s#(https?://[^\s\b,]+)#'<a href="' . $rs_href->($1) . '" target="_blank">' . shorten_url($1) . '</a>'#ge;
+        $value =~ s#(https?://[^\s\b,]*[^\s\b,.?!;)])#'<a href="' . $rs_href->($1) . '" target="_blank">' . shorten_url($1) . '</a>'#ge;
     }
 
     # bugzilla urls


### PR DESCRIPTION
This better handles text like:
* See https://example.com/example.html.
* See https://example.com/example.html!
* (See https://example.com/example.html)

While still matching:
* https://msdn.microsoft.com/en-us/library/windows/desktop/hh920508(v=vs.85).aspx

This would greatly reduce the number of times I get a 404 every day :)